### PR TITLE
laba 10 +dotnet format

### DIFF
--- a/SpaceBattle.Tests/StepDefinition/Adapter.Tests.cs
+++ b/SpaceBattle.Tests/StepDefinition/Adapter.Tests.cs
@@ -1,0 +1,50 @@
+﻿namespace SpaceBattle.Test;
+
+using _Vector;
+using Hwdtech;
+using Hwdtech.Ioc;
+using Xunit;
+
+public class AdapterGeneratorTests
+{
+    public AdapterGeneratorTests()
+    {
+        new InitScopeBasedIoCImplementationCommand().Execute();
+        IoC.Resolve<ICommand>("Scopes.Current.Set", IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"))).Execute();
+
+        IoC.Resolve<ICommand>("IoC.Register", "Game.Reflection.GenerateAdapterCode", (object[] args) => new AdapterCodeGeneratorStrategy().Run(args)).Execute();
+    }
+
+    [Fact]
+    public void AdapterCodeGeneratorTest_1()
+    {
+
+        var MoveStartableAdapterCode =
+       @"class MoveCommandStartableAdapter : IMoveCommandStartable {
+        Object target;
+        public MoveCommandStartableAdapter(Object target) => this.target = target; 
+        public IUObject UObject {
+               get { return IoC.Resolve<IUObject>(""Game.UObject.Get"", target); }
+        }
+        public IDictionary<String, Object> Dict {
+               get { return IoC.Resolve<IDictionary<String, Object>>(""Game.Dict.Get"", target); }
+        }
+    }";
+
+        var MovableAdapterCode =
+        @"class MovableAdapter : IMovable {
+        Vector target;
+        public MovableAdapter(Vector target) => this.target = target; 
+        public Vector Location {
+               get { return IoC.Resolve<Vector>(""Game.Location.Get"", target); }
+               set { IoC.Resolve<_ICommand.ICommand>(""Game.Location.Set"", target, value).Execute(); }
+        }
+        public Vector Velosity {
+               get { return IoC.Resolve<Vector>(""Game.Velosity.Get"", target); }
+        }
+    }";
+
+        Assert.Equal(MoveStartableAdapterCode, IoC.Resolve<string>("Game.Reflection.GenerateAdapterCode", typeof(IMoveCommandStartable), typeof(object)));
+        Assert.Equal(MovableAdapterCode, IoC.Resolve<string>("Game.Reflection.GenerateAdapterCode", typeof(_IMovable.IMovable), typeof(Vector)));
+    }
+}

--- a/SpaceBattle/AdapterBuilder.cs
+++ b/SpaceBattle/AdapterBuilder.cs
@@ -1,0 +1,77 @@
+﻿using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace SpaceBattle;
+
+public class AdapterBuilder
+{
+    private readonly string adaptername;
+    private readonly string adaptertypename;
+    private readonly string targettypename;
+    private string? properties;
+
+    public AdapterBuilder(Type adaptertype, Type targettype)
+    {
+        adaptername = adaptertype.Name.Substring(1);
+        adaptertypename = adaptertype.Name;
+        targettypename = FormatGenericType(targettype);
+    }
+
+    public void CreateProperty(PropertyInfo p)
+    {
+        string get = string.Empty, set = string.Empty;
+
+        var propertyname = FormatGenericType(p.PropertyType);
+
+        if (p.CanRead)
+        {
+            get = $@"   get {{ return IoC.Resolve<{propertyname}>(""Game.{p.Name}.Get"", target); }}";
+        }
+
+        if (p.CanWrite)
+        {
+            set = $@"   set {{ IoC.Resolve<_ICommand.ICommand>(""Game.{p.Name}.Set"", target, value).Execute(); }}";
+        }
+
+        properties +=
+        $@"
+        public {propertyname} {p.Name} {{
+            {get}
+            {set}
+        }}
+        ";
+    }
+
+    private static string FormatGenericType(Type type)
+    {
+        var typeName = type.Name;
+
+        if (type.IsGenericType)
+        {
+            typeName = typeName.Substring(0, typeName.IndexOf('`'));
+
+            var typeArgs = type.GetGenericArguments();
+            var typeArgNames = new string[typeArgs.Length];
+            for (var i = 0; i < typeArgs.Length; i++)
+            {
+                typeArgNames[i] = FormatGenericType(typeArgs[i]);
+            }
+
+            typeName = $"{typeName}<{string.Join(", ", typeArgNames)}>";
+        }
+
+        return typeName;
+    }
+
+    public string Build()
+    {
+        var result = @$"class {adaptername}Adapter : {adaptertypename} {{
+        {targettypename} target;
+        public {adaptername}Adapter({targettypename} target) => this.target = target; 
+        {properties}
+    }}";
+
+        result = Regex.Replace(result, @"^\s+$[\r\n]*", string.Empty, RegexOptions.Multiline);
+        return result;
+    }
+}

--- a/SpaceBattle/AdapterGeneratorStrategy.cs
+++ b/SpaceBattle/AdapterGeneratorStrategy.cs
@@ -1,0 +1,23 @@
+﻿using System.Reflection;
+
+namespace SpaceBattle;
+
+public class AdapterCodeGeneratorStrategy : IStrategy
+{
+    public object Run(params object[] args)
+    {
+        var adapterType = (Type)args[0];
+        var targetType = (Type)args[1];
+
+        var builder = new AdapterBuilder(adapterType, targetType);
+
+        var properties = adapterType.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+        foreach (var p in properties)
+        {
+            builder.CreateProperty(p);
+        }
+
+        return builder.Build();
+    }
+}


### PR DESCRIPTION
Ряд команд, реализующих поведение космического корабля и других игровых объектов, устроены следующим образом:

class SomeCommand: ICommand
{
private CommandTarget target;

public SomeCommand(CommandTarget target) => this.target = target;

public void Execute()
{
	// реализация команды, которая обращается к объекту target.
}
}

Часто получение объекта такой Команды выполняется с помощью следующего кода:

IoC.Resolve(“SomeCommand”, obj);

где obj - объект, для которого будет выполнена создаваемая Команда. При этом стратегия для разрешения зависимости определяется следующим образом.

IoC.Resolve(
“IoC.Register”,
“SomeCommand”,
(Func<object[], object>)(args) => {
var adapter = IoC.Resolve(
“Adapter for SomeCommandTarget”,
args[0]
);

return new SomeCommand(adapter);
}
).Execute();

IoC.Resolve(
“IoC.Register”,
“Adapter for SomeCommandTarget”,
(Func<object[], object>)(args) => return new SomeCommandTargetAdapter(args[0])
}
).Execute();

Для разных команд этот код отличается только типами самой команды SomeCommand, SomeCommandTarget и необходимостью написания класса SomeCommandTargetAdapter.

Если бы не класс SomeCommandTargetAdapter, то можно было бы обобщить данную стратегию до одного класса и избавиться от необходимости дублирования данного кода. Если использовать кодогенерацию и рефлексию, то можно этот класс сгенерировать автоматически, используя лишь определение интерфейса SomeCommandTarget.

Компиляция кода адаптера и стратегия создания адаптера по интерфейсу.